### PR TITLE
Fix scroll to time

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -59,7 +59,7 @@ class Selection {
     // https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
     this._onTouchMoveWindowListener = addEventListener(
       'touchmove',
-      () => {},
+      () => { },
       window
     )
     this._onKeyDownListener = addEventListener('keydown', this._keyListener)
@@ -317,6 +317,9 @@ class Selection {
   }
 
   _handleMoveEvent(e) {
+    if (!this._initialEventData) {
+      return;
+    }
     let { x, y } = this._initialEventData
     const { pageX, pageY } = getEventCoordinates(e)
     let w = Math.abs(x - pageX)
@@ -403,15 +406,15 @@ export function objectsCollide(nodeA, nodeB, tolerance = 0) {
   } = getBoundsForNode(nodeB)
 
   return !// 'a' bottom doesn't touch 'b' top
-  (
-    aBottom - tolerance < bTop ||
-    // 'a' top doesn't touch 'b' bottom
-    aTop + tolerance > bBottom ||
-    // 'a' right doesn't touch 'b' left
-    aRight - tolerance < bLeft ||
-    // 'a' left doesn't touch 'b' right
-    aLeft + tolerance > bRight
-  )
+    (
+      aBottom - tolerance < bTop ||
+      // 'a' top doesn't touch 'b' bottom
+      aTop + tolerance > bBottom ||
+      // 'a' right doesn't touch 'b' left
+      aRight - tolerance < bLeft ||
+      // 'a' left doesn't touch 'b' right
+      aLeft + tolerance > bRight
+    )
 }
 
 /**

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -3,7 +3,7 @@ import closest from 'dom-helpers/query/closest'
 import events from 'dom-helpers/events'
 
 function addEventListener(type, handler, target = document) {
-  events.on(target, type, handler, { passive: false })
+  events.on(target, type, handler)
   return {
     remove() {
       events.off(target, type, handler)
@@ -59,7 +59,7 @@ class Selection {
     // https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
     this._onTouchMoveWindowListener = addEventListener(
       'touchmove',
-      () => { },
+      () => {},
       window
     )
     this._onKeyDownListener = addEventListener('keydown', this._keyListener)
@@ -318,7 +318,7 @@ class Selection {
 
   _handleMoveEvent(e) {
     if (!this._initialEventData) {
-      return;
+      return
     }
     let { x, y } = this._initialEventData
     const { pageX, pageY } = getEventCoordinates(e)
@@ -406,15 +406,15 @@ export function objectsCollide(nodeA, nodeB, tolerance = 0) {
   } = getBoundsForNode(nodeB)
 
   return !// 'a' bottom doesn't touch 'b' top
-    (
-      aBottom - tolerance < bTop ||
-      // 'a' top doesn't touch 'b' bottom
-      aTop + tolerance > bBottom ||
-      // 'a' right doesn't touch 'b' left
-      aRight - tolerance < bLeft ||
-      // 'a' left doesn't touch 'b' right
-      aLeft + tolerance > bRight
-    )
+  (
+    aBottom - tolerance < bTop ||
+    // 'a' top doesn't touch 'b' bottom
+    aTop + tolerance > bBottom ||
+    // 'a' right doesn't touch 'b' left
+    aRight - tolerance < bLeft ||
+    // 'a' left doesn't touch 'b' right
+    aLeft + tolerance > bRight
+  )
 }
 
 /**

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -285,8 +285,11 @@ export default class TimeGrid extends Component {
 
   applyScroll() {
     if (this._scrollRatio) {
-      const { content } = this.refs
-      content.scrollTop = content.scrollHeight * this._scrollRatio
+      const { content } = this.refs;
+      const scrollRatio = this._scrollRatio;
+      setTimeout(() => {
+        content.scrollTop = content.scrollHeight * scrollRatio;
+      }, 2);
       // Only do this once
       this._scrollRatio = null
     }


### PR DESCRIPTION
This pull request fixes;

1. Issue with scrollToTime not working on initial load. At initial load, the element isn't scrollable and setting scrollTop has no effect. A timeout is added before setting the scrollTop on the element. This was done in TimeGrid.js

2. Issue with dragging and resizing on Internet explorer. The calendar upgrade added an options object that contains the passive option. However, the dom helper used to add events listener is expecting a capture boolean argument and evaluates the options object as true. Seems like IE doesn't do well with capture set as true.

3. `!this._initialEventData` check was added  as IE was throwing errors around `let { x, y } = this._initialEventData` in the Selection.js file